### PR TITLE
fix tests

### DIFF
--- a/server/src/test/java/se/sperber/cryson/apitest/CrysonAPITest.java
+++ b/server/src/test/java/se/sperber/cryson/apitest/CrysonAPITest.java
@@ -39,7 +39,6 @@ import se.sperber.cryson.testutil.CrysonTestChildEntity;
 import se.sperber.cryson.testutil.CrysonTestEntity;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Collections;
 

--- a/server/src/test/java/se/sperber/cryson/apitest/CrysonAPITest.java
+++ b/server/src/test/java/se/sperber/cryson/apitest/CrysonAPITest.java
@@ -31,15 +31,17 @@ import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import se.sperber.cryson.CrysonServer;
 import se.sperber.cryson.initialization.Application;
 import se.sperber.cryson.serialization.CrysonSerializer;
+import se.sperber.cryson.testutil.CrysonTestChildEntity;
 import se.sperber.cryson.testutil.CrysonTestEntity;
 
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.Collections;
 
 import static org.junit.Assert.*;
 
@@ -76,6 +78,35 @@ public class CrysonAPITest {
     session.createSQLQuery("DELETE FROM CrysonTestEntity").executeUpdate();
     session.getTransaction().commit();
     session.close();
+  }
+
+  @Before
+  public void createEntities() throws IOException {
+    String serializedEntity = "{\"id\":null, \"name\":\"created\", \"childEntities_cryson_ids\":[100]}";
+    PutMethod entityPutMethod = new PutMethod("http://localhost:8789/cryson/CrysonTestEntity");
+    entityPutMethod.setRequestEntity(new StringRequestEntity(serializedEntity, "application/json", "UTF-8"));
+    httpClient.executeMethod(entityPutMethod);
+
+    CrysonTestEntity testEntity = crysonSerializer.deserialize(entityPutMethod.getResponseBodyAsString(), CrysonTestEntity.class, null);
+    String serializedChildEntity = "{\"id\":null,\"parent_cryson_id\":" + testEntity.getId() + "}";
+    PutMethod childEntityPutMethod = new PutMethod("http://localhost:8789/cryson/CrysonTestChildEntity");
+    childEntityPutMethod.setRequestEntity(new StringRequestEntity(serializedChildEntity, "application/json", "UTF-8"));
+    httpClient.executeMethod(childEntityPutMethod);
+    CrysonTestChildEntity testChildEntity= crysonSerializer.deserialize(childEntityPutMethod.getResponseBodyAsString(), CrysonTestChildEntity.class, null);
+    testEntity.setChildEntities(Collections.singleton(testChildEntity));
+
+    GetMethod getMethod = new GetMethod("http://localhost:8789/cryson/CrysonTestEntity/all");
+    int status = httpClient.executeMethod(getMethod);
+    assertEquals(HttpStatus.SC_OK, status);
+
+    JsonElement jsonElement = crysonSerializer.parse(getMethod.getResponseBodyAsString());
+    assertEquals(1, jsonElement.getAsJsonArray().size());
+    foundEntity = crysonSerializer.deserialize(jsonElement.getAsJsonArray().get(0), CrysonTestEntity.class, null);
+  }
+
+  @After
+  public void cleanEntities(){
+    cleanDatabase();
   }
 
   @AfterClass
@@ -243,12 +274,10 @@ public class CrysonAPITest {
     assertEquals(HttpStatus.SC_OK, httpClient.executeMethod(postMethod));
     assertEquals("{\"replacedTemporaryIds\":{},\"persistedEntities\":[],\"updatedEntities\":[{\"id\":" + entityId + ",\"name\":\"updated\",\"version\":1,\"crysonEntityClass\":\"CrysonTestEntity\",\"doubleId\":" + (entityId*2) + ",\"childEntities_cryson_ids\":[]}]}", postMethod.getResponseBodyAsString());
   }
-
   @Test
   public void shouldNotCommitStaleEntities() throws Exception {
     Long entityId = foundEntity.getId();
-    Long childEntityId = foundEntity.getChildEntities().iterator().next().getId();
-    String commitJson = "{\"updatedEntities\":[{\"crysonEntityClass\":\"CrysonTestEntity\",\"id\":" + entityId + ",\"name\":\"will not update\",\"childEntities_cryson_ids\":[]}], \"deletedEntities\":[], \"persistedEntities\":[]}";
+    String commitJson = "{\"updatedEntities\":[{\"crysonEntityClass\":\"CrysonTestEntity\",\"id\":" + entityId + ",\"name\":\"will not update\",\"version\":1,\"childEntities_cryson_ids\":[]}], \"deletedEntities\":[], \"persistedEntities\":[]}";
 
     PostMethod postMethod = new PostMethod("http://localhost:8789/cryson/commit");
     postMethod.setRequestEntity(new StringRequestEntity(commitJson, "application/json", "UTF-8"));


### PR DESCRIPTION
Before apply changes to cryson, fix the failing tests first.
One thing to notice: the current version 0.9.3 and 0.9.2 share the same code.
<img width="1676" alt="Screenshot 2023-10-09 at 16 49 04" src="https://github.com/deltaprojects/cryson/assets/33903745/ecc6bdc0-0522-45a2-a3a3-6b0db5d5bddb">

I downloaded both 0.9.2 and 0.9.3 and compared them with current master branch. it turns out they are the same source code.
http://mavenrepo.service.delta.prod/artifactory/webapp/#/artifacts/browse/tree/General/libs-releases-local/se/sperber/cryson/cryson/0.9.2/cryson-0.9.2-sources.jar
http://mavenrepo.service.delta.prod/artifactory/webapp/#/artifacts/browse/tree/General/libs-releases-local/se/sperber/cryson/cryson/0.9.3/cryson-0.9.3-sources.jar

The PR to improve performance will come later from https://github.com/deltaprojects/cryson/tree/DD-1113-boris-performance-improve